### PR TITLE
Can signup/login/logout on toppage

### DIFF
--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -41,7 +41,7 @@
         - else
           %ul.signin-signup
             %li.signin-btn
-              = link_to "ログイン",root_path ,class: "signin-btn__text"
+              = link_to "ログイン",new_user_session_path ,class: "signin-btn__text"
             %li.signup-btn
-              = link_to "新規会員登録",root_path ,class: "signup-btn__text"
+              = link_to "新規会員登録",new_user_registration_path ,class: "signup-btn__text"
 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -12,6 +12,3 @@
 = render 'sell-button'
 
 = render 'footer'
-
-
-

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,6 +1,10 @@
 .default-container
   = render 'header'
 
+// ログアウトの仮置き
+.informal
+= link_to "ログアウト", destroy_user_session_path, method: :delete
+
 / トップページの商品一覧(カテゴリー別新着アイテム最大4点)今はカテゴリーは考えず作っています
 %main.mainpage
   = render 'items'
@@ -8,3 +12,6 @@
 = render 'sell-button'
 
 = render 'footer'
+
+
+

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -9,7 +9,7 @@
       %form.chapter-container__single-inner
         .chapter-container__single-inner__content
           %button{ type: 'submit', class: 'btn-default btn-red' }
-            ログアウト
+            = link_to "ログアウト", destroy_user_session_path, method: :delete
           %input{ type: 'hidden', name: '__csrf_value'}
 
 = render 'items/footer'


### PR DESCRIPTION
#what
トップページの新規登録、ログインボタンを使用できるようにした
ログアウトページのボタンも使える
トップページ左上に仮置きのログアウトページを設置
