### PR TITLE
Late page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,21 +27,21 @@ class ApplicationController < ActionController::Base
 
   def set_late_count
     item = Item.find(params[:id])
-    @good = Late.where(user_id: item.user.id).where(late: 1)
+    @good = Late.where(late_user: item.user.id).where(late: 1)
     @good_count = @good.length
-    @normal = Late.where(user_id: item.user.id).where(late: 2)
+    @normal = Late.where(late_user: item.user.id).where(late: 2)
     @normal_count = @normal.length
-    @bad = Late.where(user_id: item.user.id).where(late: 3)
+    @bad = Late.where(late_user: item.user.id).where(late: 3)
     @bad_count = @bad.length
   end
 
   def user_late_count
     user = User.find(params[:id])
-    @good = Late.where(user_id: user.id).where(late: 1)
+    @good = Late.where(late_user: user.id).where(late: 1)
     @good_count = @good.length
-    @normal = Late.where(user_id: user.id).where(late: 2)
+    @normal = Late.where(late_user: user.id).where(late: 2)
     @normal_count = @normal.length
-    @bad = Late.where(user_id: user.id).where(late: 3)
+    @bad = Late.where(late_user: user.id).where(late: 3)
     @bad_count = @bad.length
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -170,8 +170,8 @@ class ItemsController < ApplicationController
       @item.delivery_status = '3'
       @item.business_stats = '3'
       @late = Late.new(late_params)
-      @late.user_id = @item.buyer_id
-      @late.late_user = @item.user_id
+      @late.user_id = @item.user_id
+      @late.late_user = @item.buyer_id
       @buyer.late_count += 1
       @buyer.save(validate: false)
       @late.save(validate: false)
@@ -199,8 +199,8 @@ class ItemsController < ApplicationController
     @seller = User.find(@item.user_id)
     if @item.delivery_status == 1
       @late = Late.new(late_params)
-      @late.user_id = @item.user_id
-      @late.late_user = @item.buyer_id
+      @late.user_id = @item.buyer_id
+      @late.late_user = @item.user_id
       @seller.late_count += 1
       @seller.save(validate: false)
       @late.save(validate: false)

--- a/app/controllers/lates_controller.rb
+++ b/app/controllers/lates_controller.rb
@@ -2,7 +2,6 @@ class LatesController < ApplicationController
   before_action :set_user
   before_action :set_search
   before_action :set_category
-  before_action :set_text
 
   def index
     @lates = Late.where(late_user: @user.id).order(id: "DESC")
@@ -24,10 +23,6 @@ class LatesController < ApplicationController
 
   def set_user
     @user = User.find(current_user)
-  end
-
-  def set_text
-    @text = @user.lates.all
   end
 
 end

--- a/app/views/lates/good.html.haml
+++ b/app/views/lates/good.html.haml
@@ -13,7 +13,7 @@
       .tab-content
         %ul#mypage-tab-transaction-now.mypage-item-list.tab-pane.active
           - if @lates.present?
-            - @lates.zip(@text).each do |late,text|
+            - @lates.each do |late|
               %li.mypage-item-lists
                 = link_to individual_user_path(late.user.id),class: 'mypage-item-lists__link' do
                   %figure
@@ -23,9 +23,9 @@
                       = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", alt: ""
                   .mypage-item-lists__body
                     .mypage-item-lists__body--text
-                      - if text&.late == 1
+                      - if late&.late == 1
                         %i.fa.fa-grin.icon-good
-                      - elsif text&.late == 2
+                      - elsif late&.late == 2
                         %i.fa.fa-meh.icon-normal
                       - else
                         %i.fa.fa-frown.icon-bad
@@ -34,7 +34,7 @@
                     .mypage-item-lists__body--text
                       = late.user.nickname
                     .mypage-item-lists__body--text
-                      = text&.text
+                      = late&.text
                     .mypage-item-lists__body--text.time
                       %i.fa.fa-clock-o.icon-time
                       %span

--- a/app/views/lates/good.html.haml
+++ b/app/views/lates/good.html.haml
@@ -23,12 +23,7 @@
                       = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", alt: ""
                   .mypage-item-lists__body
                     .mypage-item-lists__body--text
-                      - if late&.late == 1
-                        %i.fa.fa-grin.icon-good
-                      - elsif late&.late == 2
-                        %i.fa.fa-meh.icon-normal
-                      - else
-                        %i.fa.fa-frown.icon-bad
+                      %i.fa.fa-meh.icon-normal
                       %span
                         購入者
                     .mypage-item-lists__body--text

--- a/app/views/lates/great.html.haml
+++ b/app/views/lates/great.html.haml
@@ -13,7 +13,7 @@
       .tab-content
         %ul#mypage-tab-transaction-now.mypage-item-list.tab-pane.active
           - if @lates.present?
-            - @lates.zip(@text).each do |late,text|
+            - @lates.each do |late|
               %li.mypage-item-lists
                 = link_to individual_user_path(late.user.id),class: 'mypage-item-lists__link' do
                   %figure
@@ -23,9 +23,9 @@
                       = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", alt: ""
                   .mypage-item-lists__body
                     .mypage-item-lists__body--text
-                      - if text&.late == 1
+                      - if late&.late == 1
                         %i.fa.fa-grin.icon-good
-                      - elsif text&.late == 2
+                      - elsif late&.late == 2
                         %i.fa.fa-meh.icon-normal
                       - else
                         %i.fa.fa-frown.icon-bad
@@ -34,7 +34,7 @@
                     .mypage-item-lists__body--text
                       = late.user.nickname
                     .mypage-item-lists__body--text
-                      = text&.text
+                      = late&.text
                     .mypage-item-lists__body--text.time
                       %i.fa.fa-clock-o.icon-time
                       %span

--- a/app/views/lates/great.html.haml
+++ b/app/views/lates/great.html.haml
@@ -23,12 +23,7 @@
                       = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", alt: ""
                   .mypage-item-lists__body
                     .mypage-item-lists__body--text
-                      - if late&.late == 1
-                        %i.fa.fa-grin.icon-good
-                      - elsif late&.late == 2
-                        %i.fa.fa-meh.icon-normal
-                      - else
-                        %i.fa.fa-frown.icon-bad
+                      %i.fa.fa-grin.icon-good
                       %span
                         購入者
                     .mypage-item-lists__body--text

--- a/app/views/lates/index.html.haml
+++ b/app/views/lates/index.html.haml
@@ -13,7 +13,7 @@
       .tab-content
         %ul#mypage-tab-transaction-now.mypage-item-list.tab-pane.active
           - if @lates.present?
-            - @lates.zip(@text).each do |late,text|
+            - @lates.each do |late|
               %li.mypage-item-lists
                 = link_to individual_user_path(late.user.id),class: 'mypage-item-lists__link' do
                   %figure
@@ -23,9 +23,9 @@
                       = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", alt: ""
                   .mypage-item-lists__body
                     .mypage-item-lists__body--text
-                      - if text&.late == 1
+                      - if late&.late == 1
                         %i.fa.fa-grin.icon-good
-                      - elsif text&.late == 2
+                      - elsif late&.late == 2
                         %i.fa.fa-meh.icon-normal
                       - else
                         %i.fa.fa-frown.icon-bad
@@ -34,7 +34,7 @@
                     .mypage-item-lists__body--text
                       = late.user.nickname
                     .mypage-item-lists__body--text
-                      = text&.text
+                      = late&.text
                     .mypage-item-lists__body--text.time
                       %i.fa.fa-clock-o.icon-time
                       %span

--- a/app/views/lates/poor.html.haml
+++ b/app/views/lates/poor.html.haml
@@ -13,7 +13,7 @@
       .tab-content
         %ul#mypage-tab-transaction-now.mypage-item-list.tab-pane.active
           - if @lates.present?
-            - @lates.zip(@text).each do |late,text|
+            - @lates.each do |late|
               %li.mypage-item-lists
                 = link_to individual_user_path(late.user.id),class: 'mypage-item-lists__link' do
                   %figure
@@ -23,9 +23,9 @@
                       = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", alt: ""
                   .mypage-item-lists__body
                     .mypage-item-lists__body--text
-                      - if text&.late == 1
+                      - if late&.late == 1
                         %i.fa.fa-grin.icon-good
-                      - elsif text&.late == 2
+                      - elsif late&.late == 2
                         %i.fa.fa-meh.icon-normal
                       - else
                         %i.fa.fa-frown.icon-bad
@@ -34,7 +34,7 @@
                     .mypage-item-lists__body--text
                       = late.user.nickname
                     .mypage-item-lists__body--text
-                      = text&.text
+                      = late&.text
                     .mypage-item-lists__body--text.time
                       %i.fa.fa-clock-o.icon-time
                       %span

--- a/app/views/lates/poor.html.haml
+++ b/app/views/lates/poor.html.haml
@@ -23,12 +23,7 @@
                       = image_tag "//static.mercdn.net/images/member_photo_noimage_thumb.png", alt: ""
                   .mypage-item-lists__body
                     .mypage-item-lists__body--text
-                      - if late&.late == 1
-                        %i.fa.fa-grin.icon-good
-                      - elsif late&.late == 2
-                        %i.fa.fa-meh.icon-normal
-                      - else
-                        %i.fa.fa-frown.icon-bad
+                      %i.fa.fa-frown.icon-bad
                       %span
                         購入者
                     .mypage-item-lists__body--text


### PR DESCRIPTION
WHAT
取引完了時にレイトテーブルのユーザーIDに入れるIDが逆になっていたので、評価一覧ページとその他評価数を表示するページ（マイページ、商品詳細）修正したので確認お願いします。これまでに保存されたデータはデータベースのデータをいじらないと正しく表示されませんが、これから保存されるデータに関しては正しく表示されるかと思います。